### PR TITLE
Fix/test failures

### DIFF
--- a/tests/testthat/locale_test/en.yaml
+++ b/tests/testthat/locale_test/en.yaml
@@ -1,0 +1,4 @@
+myslang:
+ hi: Zup
+ surprise: WTF!
+hello: Hello

--- a/tests/testthat/locale_test/es.yaml
+++ b/tests/testthat/locale_test/es.yaml
@@ -1,0 +1,4 @@
+myslang:
+ hi: Quiubo
+ surprise: ¡Mierda!
+hello: Hola!!!

--- a/tests/testthat/test-list-translations.R
+++ b/tests/testthat/test-list-translations.R
@@ -1,7 +1,7 @@
 
 test_that("list translations work",{
 
-  localeDir <- system.file("examples/locale",package = "shi18ny")
+  localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
   opts <- list(
     localeDir = localeDir,
     defaultLang = "es",

--- a/tests/testthat/test_shi18ny_config.R
+++ b/tests/testthat/test_shi18ny_config.R
@@ -26,7 +26,7 @@ test_that("i18n Config",{
   # expect_equal(selectInList(l,strs), c("common", "language"))
 
 
-  localeDir <- system.file("examples/locale",package = "shi18ny")
+  localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
   opts <- list(
     localeDir = localeDir,
     availableLangs = c("en","es")

--- a/tests/testthat/test_translations.R
+++ b/tests/testthat/test_translations.R
@@ -4,7 +4,7 @@ test_that("i18n Config",{
 
   # Custom translations
 
-  localeDir <- system.file("examples/locale",package = "shi18ny")
+  localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
   opts <- list(
     localeDir = localeDir,
     defaultLang = "es",


### PR DESCRIPTION
Fix test failures by
- adding new "locale_test" directory which contains en.yaml and es.yaml for test (otherwise the tests that *don't* use custom translations fail, as they automatically use the custom translations when they're in the "local" folder)
- updating directory calls in the test files