### PR TITLE
Fix/update i function

### DIFF
--- a/R/i18n.R
+++ b/R/i18n.R
@@ -82,7 +82,12 @@
 #' @export
 i_ <- function(str, lang = NULL, i18n = NULL, markdown = FALSE,
                keys = c("name","label")){
-  if(is.null(i18n)) i18n <- i18nLoad()
+
+  i18n_is_null <- is.null(i18n)
+  i18n_not_yet_processed <- !(is.null(i18n) | (".config" %in% names(i18n)))
+
+  if(i18n_is_null | i18n_not_yet_processed) i18n <- i18nLoad(i18n)
+
   lang <- lang %||% "en"
   if(is.null(str)) return()
 

--- a/tests/testthat/test-list-translations.R
+++ b/tests/testthat/test-list-translations.R
@@ -2,13 +2,12 @@
 test_that("list translations work",{
 
   localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
-  opts <- list(
+  i18n <- list(
     localeDir = localeDir,
     defaultLang = "es",
     fallbacks = list("es" = "en")
   )
-  config <- i18nConfig(opts)
-  i18n <- i18nLoad(opts)
+  config <- i18nConfig(i18n)
 
   l <- list(label = "hello", numbers = "abort",
             custom_text = "myslang.hi",

--- a/tests/testthat/test_translations.R
+++ b/tests/testthat/test_translations.R
@@ -5,13 +5,12 @@ test_that("i18n Config",{
   # Custom translations
 
   localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
-  opts <- list(
+  i18n <- list(
     localeDir = localeDir,
     defaultLang = "es",
     fallbacks = list("es" = "en")
   )
-  config <- i18nConfig(opts)
-  i18n <- i18nLoad(opts)
+  config <- i18nConfig(i18n)
 
   expect_equal(i_("myslang.hi","es",i18n), "Quiubo")
   expect_equal(i_("myslang.hi","en",i18n), "Zup")


### PR DESCRIPTION
Update `i_` function so that one doesn't have to call `i18n <- i18nLoad(i18n)` before.

E.g. the following now works *without* the uncommented code (before it only worked with the i18nLoad:

localeDir = "dir_with_custom_yaml_files"

```
i18n <- list(
  defaultLang = "en",
  localeDir = localeDir,
  availableLangs = c("en", "de")
  )

# i18n <- i18nLoad(i18n)

i_("choose_file", "de", i18n = i18n)
```