### PR TITLE
Fix langselector temporarily

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -143,7 +143,6 @@ langSelector <- function(input, output, session,
   # })
 #
 #   observe({
-#     # browser()
 #     updateSelectLangInput(session, 'langInner',
 #                           langs = config$availableLangs,
 #                           selected = queryLang() %||% config$defaultLang)

--- a/R/modules.R
+++ b/R/modules.R
@@ -113,40 +113,50 @@ langSelector <- function(input, output, session,
                          i18n = NULL, showSelector = TRUE){
   i18n <- i18nLoad(i18n)
   config <- i18n$.config
+
   queryLang <- reactive({
     query <- parseQueryString(session$clientData$url_search)
     query[[config$queryParameter]]
   })
+
   # observe({
-  initLocale <- reactive({
-    selected <- queryLang() %||% config$defaultLang
-    message("selected2 ", selected," config ", config$defaultLang)
-    message(showSelector)
-    if(showSelector){
-      #   message(showSelector)
-      #   return(queryLang())
-      # }else{
-      shinyjs::show("langContainer")
-    }
-    message("config_av_langs",config$availableLangs)
-    updateSelectLangInput(session, 'langInner',
-                          langs = config$availableLangs,
-                          selected = selected)
-    # return(reactive(selected))
-    #selected <- queryLang()
-    # if(is.null(selected)) return(config$defaultLang)
-    # if(!showSelector) return(selected)
-    message("selected3", selected, " config ", config$defaultLang)
-    selected
-  })
+  # initLocale <- reactive({
+  #   selected <- queryLang() %||% config$defaultLang
+  #   message("selected2 ", selected," config ", config$defaultLang)
+  #   message(showSelector)
+  #   if(showSelector){
+  #     #   message(showSelector)
+  #     #   return(queryLang())
+  #     # }else{
+  #     shinyjs::show("langContainer")
+  #   }
+  #   message("config_av_langs",config$availableLangs)
+  #   updateSelectLangInput(session, 'langInner',
+  #                         langs = config$availableLangs,
+  #                         selected = selected)
+  #   # return(reactive(selected))
+  #   #selected <- queryLang()
+  #   # if(is.null(selected)) return(config$defaultLang)
+  #   # if(!showSelector) return(selected)
+  #   message("selected3", selected, " config ", config$defaultLang)
+  #   selected
+  # })
+#
+#   observe({
+#     # browser()
+#     updateSelectLangInput(session, 'langInner',
+#                           langs = config$availableLangs,
+#                           selected = queryLang() %||% config$defaultLang)
+#   })
 
   currentLocale <- reactive({
-    initLocale()
-    message("initLocale: ", initLocale())
-    message("input3 ", input$langInner, " is null ",is.null(input$langInner))
+    # initLocale()
+    # message("initLocale: ", initLocale())
+    message("input3 ", queryLang(), " is null ",is.null(queryLang()))
     # if(is.null(input$langInner))
     #   return(initLocale())
-    input$langInner
+    queryLang()
+    # browser()
   })
   currentLocale
 }

--- a/R/modules.R
+++ b/R/modules.R
@@ -119,43 +119,31 @@ langSelector <- function(input, output, session,
     query[[config$queryParameter]]
   })
 
-  # observe({
-  # initLocale <- reactive({
-  #   selected <- queryLang() %||% config$defaultLang
-  #   message("selected2 ", selected," config ", config$defaultLang)
-  #   message(showSelector)
-  #   if(showSelector){
-  #     #   message(showSelector)
-  #     #   return(queryLang())
-  #     # }else{
-  #     shinyjs::show("langContainer")
-  #   }
-  #   message("config_av_langs",config$availableLangs)
-  #   updateSelectLangInput(session, 'langInner',
-  #                         langs = config$availableLangs,
-  #                         selected = selected)
-  #   # return(reactive(selected))
-  #   #selected <- queryLang()
-  #   # if(is.null(selected)) return(config$defaultLang)
-  #   # if(!showSelector) return(selected)
-  #   message("selected3", selected, " config ", config$defaultLang)
-  #   selected
-  # })
-#
-#   observe({
-#     updateSelectLangInput(session, 'langInner',
-#                           langs = config$availableLangs,
-#                           selected = queryLang() %||% config$defaultLang)
-#   })
+  initLocale <- reactive({
+    selected <- queryLang() %||% config$defaultLang
+
+    message("selected2 ", selected," config ", config$defaultLang)
+    message(showSelector)
+
+    if(showSelector){
+      shinyjs::show("langContainer")
+    }
+    message("config_av_langs",config$availableLangs)
+
+    # updateSelectLangInput(session, 'langInner',
+    #                       langs = config$availableLangs,
+    #                       selected = selected)
+
+    message("selected3", selected, " config ", config$defaultLang)
+    selected
+  })
 
   currentLocale <- reactive({
-    # initLocale()
-    # message("initLocale: ", initLocale())
+    initLocale()
+    message("initLocale: ", initLocale())
     message("input3 ", queryLang(), " is null ",is.null(queryLang()))
-    # if(is.null(input$langInner))
-    #   return(initLocale())
+
     queryLang()
-    # browser()
   })
   currentLocale
 }

--- a/inst/examples/ex07-translate_with_parmesan/app.R
+++ b/inst/examples/ex07-translate_with_parmesan/app.R
@@ -35,7 +35,6 @@ server <-  function(input, output, session) {
 
   parmesan_lang <- reactive({
     i_(parmesan, lang(), keys = c("label", "choices"))
-    # parmesan
   })
 
   output_parmesan("all_controls_here", parmesan = parmesan_lang,
@@ -49,7 +48,6 @@ server <-  function(input, output, session) {
   output$debug <- renderPrint({
     paste0(
       "Parmesan updated: ", input$parmesan_updated
-      # str(parmesan_input())
     )
   })
 


### PR DESCRIPTION
Temporarily fixes clash with `parmesan` that blocked modal from `shinypanels::showModalMultipleId` from opening. 

This temporary fix was done removing `updateSelectLangInput` from the `initLocale` reactive in the `langSelector` function.