### PR TITLE
CurrentLocale returns default while fetching queryLang

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -143,7 +143,7 @@ langSelector <- function(input, output, session,
     message("initLocale: ", initLocale())
     message("input3 ", queryLang(), " is null ",is.null(queryLang()))
 
-    queryLang()
+    queryLang() %||% config$defaultLang
   })
   currentLocale
 }


### PR DESCRIPTION
The `currentLocale` reactive was returning `NULL` while URL was being parsed by `parseQueryString`. 

With this fix, the default language is returned while URL is being parsed.