### PR TITLE
Allow csv translations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,9 @@ Depends:
 Imports:
     shiny,
     shinyjs,
-    yaml
+    yaml,
+    dplyr,
+    purrr
 Encoding: UTF-8
 Suggests: 
     knitr,

--- a/R/config.R
+++ b/R/config.R
@@ -43,7 +43,7 @@ i18nLoad <- function(opts = NULL){
 
       message("Using translations from csv.")
       dir <- file.path(localeDir,"translations.csv")
-      all_translations <- readr::read_csv(dir)
+      all_translations <- readr::read_csv(dir, col_types = cols())
 
       data_columns <- names(all_translations)
 

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -19,14 +19,19 @@
 #'   there are currently 15 **Available languages** (see below); defaults to
 #'   all.
 #'
-#'   `localeDir` Directory to `yaml` files which contain custom keyword
-#'   translations; default = "locale"
+#'   `localeDir` Directory to `yaml` or `csv` file(s) which contain custom
+#'   keyword translations; default = "locale"
 #'
 #'   `fallbacks` List of fallback languages if translation for a word is not
 #'   found in desired language; defaults to **Default fallbacks** (see below)
 #'
 #'   `queryParameter` String to define query parameter if language to be set
 #'   through URL; default = "lang"
+#'
+#'   `customTranslationSource` String to change the type of source for custom
+#'   translations. Options: "yaml" and "csv"; default = "yaml". If "csv"
+#'   there needs to be a "translations.csv" in the `localeDir` with an "id"
+#'   column and columns for languages (e.g. "en", "es", ...)
 #'
 #' @param markdown Transform markdown text to HTML, can only be set for `i_`;
 #'   default = FALSE

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -5,7 +5,7 @@ articles:
   contributing: contributing.html
   getting-started: getting-started.html
   pull-request-guidelines: pull-request-guidelines.html
-last_built: 2021-03-10T17:38Z
+last_built: 2021-03-13T00:00Z
 urls:
   reference: https://shi18ny.datasketch.dev/reference
   article: https://shi18ny.datasketch.dev/articles

--- a/docs/reference/i18n.html
+++ b/docs/reference/i18n.html
@@ -185,12 +185,16 @@ Options that can be set are:</p>
 <p><code>availableLangs</code> Language that can be chosen for translation in Shiny app;
 there are currently 15 <strong>Available languages</strong> (see below); defaults to
 all.</p>
-<p><code>localeDir</code> Directory to <code>yaml</code> files which contain custom keyword
-translations; default = "locale"</p>
+<p><code>localeDir</code> Directory to <code>yaml</code> or <code>csv</code> file(s) which contain custom
+keyword translations; default = "locale"</p>
 <p><code>fallbacks</code> List of fallback languages if translation for a word is not
 found in desired language; defaults to <strong>Default fallbacks</strong> (see below)</p>
 <p><code>queryParameter</code> String to define query parameter if language to be set
-through URL; default = "lang"</p></td>
+through URL; default = "lang"</p>
+<p><code>customTranslationSource</code> String to change the type of source for custom
+translations. Options: "yaml" and "csv"; default = "yaml". If "csv"
+there needs to be a "translations.csv" in the <code>localeDir</code> with an "id"
+column and columns for languages (e.g. "en", "es", ...)</p></td>
     </tr>
     <tr>
       <th>markdown</th>

--- a/inst/examples/ex06-translate_covid_viz/app.R
+++ b/inst/examples/ex06-translate_covid_viz/app.R
@@ -5,7 +5,8 @@ library(leaflet)
 library(shi18ny)
 library(lfltmagic)
 
-load_data <- read.csv("tidy-csse-langs.csv")
+data_dir <- system.file("examples", "ex06-translate_covid_viz","tidy-csse-langs.csv", package = "shi18ny")
+load_data <- readr::read_csv(data_dir)
 
 max_date <- max(load_data$date)
 
@@ -32,24 +33,27 @@ ui <- fluidPage(
 
 server <- function(input, output) {
 
-  i18n <- list(
+  opts <- list(
     defaultLang = "en",
-    availableLangs = c("de","en","es")
+    availableLangs = c("de","en","es"),
+    customTranslationSource = "csv"
   )
 
-  lang <- callModule(langSelector,"lang", i18n = i18n, showSelector = TRUE)
+  i18n <- i18nLoad(opts)
+
+  lang <- callModule(langSelector,"lang", i18n = opts, showSelector = TRUE)
 
   observeEvent(lang(),{
-    uiLangUpdate(input$shi18ny_ui_classes, lang())
+    shinyjs::delay(500, uiLangUpdate(input$shi18ny_ui_classes, lang = lang(), i18n = i18n))
   })
 
   output$world_map <- renderLeaflet({
 
     # translate labels
-    country <- i_("country", lang())
-    cases <- i_("cases", lang())
-    title <- i_("title", lang())
-    subtitle <- i_("subtitle", lang())
+    country <- i_("country", lang = lang(), i18n = i18n)
+    cases <- i_("cases", lang = lang(), i18n = i18n)
+    title <- i_("title", lang = lang(), i18n = i18n)
+    subtitle <- i_("subtitle", lang = lang(), i18n = i18n)
 
     lflt_choropleth_Gcd(data,
                         map_tiles = "CartoDB",
@@ -64,7 +68,7 @@ server <- function(input, output) {
     })
 
   output$datestamp <- renderUI({
-    h6(paste0(i_("status",lang()), ": ", max_date))
+    h6(paste0(i_("status", lang = lang(), i18n = i18n), ": ", max_date))
     })
 
 }

--- a/inst/examples/ex06-translate_covid_viz/locale/translations.csv
+++ b/inst/examples/ex06-translate_covid_viz/locale/translations.csv
@@ -1,0 +1,8 @@
+id,en,es,de
+title,COVID-19 mapper,Mapeador COVID-19,COVID-19-Mapper
+subtitle,Confirmed cases<br>of COVID-19<br>in absolute numbers,Casos confirmados<br>de COVID-19<br>en nï¿½ï¿½meros abso,Bestï¿½ï¿½tigte Fï¿½ï¿½lle<br>von COVID-19<br>in absolu
+annotate,Data from the Corona Center for Systems Science and Engineering (CSSE) at Johns Hopkins University (JHU),Datos del Corona Center for Systems Science and Engineering (CSSE) de la Universidad Johns Hopkins (JHU),Daten vom Corona Center for Systems Science and Engineering (CSSE) an der Johns Hopkins Universitï¿½ï¿½t 
+status,Dated,A partir del,Stand
+internationalize,Internationalize your Shiny maps with shi18ny,Internacionaliza tus mapas Shiny con shi18ny,Internationalisiere deine Shiny-Weltkarte mit shi18ny
+country,Country,Paï¿,Land
+cases,Confirmed cases,Casos confirmados,Bestï¿½ï¿½tigte 

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -25,14 +25,19 @@ Options that can be set are:
 there are currently 15 \strong{Available languages} (see below); defaults to
 all.
 
-\code{localeDir} Directory to \code{yaml} files which contain custom keyword
-translations; default = "locale"
+\code{localeDir} Directory to \code{yaml} or \code{csv} file(s) which contain custom
+keyword translations; default = "locale"
 
 \code{fallbacks} List of fallback languages if translation for a word is not
 found in desired language; defaults to \strong{Default fallbacks} (see below)
 
 \code{queryParameter} String to define query parameter if language to be set
-through URL; default = "lang"}
+through URL; default = "lang"
+
+\code{customTranslationSource} String to change the type of source for custom
+translations. Options: "yaml" and "csv"; default = "yaml". If "csv"
+there needs to be a "translations.csv" in the \code{localeDir} with an "id"
+column and columns for languages (e.g. "en", "es", ...)}
 
 \item{markdown}{Transform markdown text to HTML, can only be set for \code{i_};
 default = FALSE}

--- a/tests/testthat/locale_csv/translations.csv
+++ b/tests/testthat/locale_csv/translations.csv
@@ -1,0 +1,3 @@
+id2,en,es
+hi,Zup,Quiubo
+surprise,WTF!,Mierda!

--- a/tests/testthat/locale_test/translations.csv
+++ b/tests/testthat/locale_test/translations.csv
@@ -1,0 +1,3 @@
+id,en,es
+hi,Zup,Quiubo
+surprise,WTF!,¡Mierda!

--- a/tests/testthat/test_shi18ny_config.R
+++ b/tests/testthat/test_shi18ny_config.R
@@ -23,7 +23,6 @@ test_that("i18n Config",{
   l <- i18nLoad()$en
   localeString <- "common.language"
   strs <- strsplit(localeString,".",fixed = TRUE)[[1]]
-  # expect_equal(selectInList(l,strs), c("common", "language"))
 
 
   localeDir <- system.file("tests", "testthat", "locale_test", package = "shi18ny")
@@ -42,13 +41,45 @@ test_that("i18n Config",{
   config <- i18nConfig(opts)
   expect_error(i18nLoad(opts),"Requested languages not in locale folder")
 
-  # TODO need to add more tests here
-  # i18n <- list(
-  #   defaultLang = "en",
-  #   availableLangs = c("es","en")
-  # )
-  # i18n <- i18nLoad(i18n)
-  # config <- i18n$.config
+  # test config works for csv translations
+  opts <- list(
+    localeDir = localeDir,
+    availableLangs = c("en","es"),
+    customTranslationSource = "csv"
+  )
+  config <- i18nConfig(opts)
+  i18n <- i18nLoad(opts)
+  expect_true(all(opts$availableLans %in% names(i18n)))
+
+  # test error when languages unavailable in "translations.csv"
+  opts <- list(
+    localeDir = localeDir,
+    availableLangs = c("en","pt"),
+    customTranslationSource = "csv"
+  )
+  config <- i18nConfig(opts)
+  expect_error(i18nLoad(opts), "Requested languages not in translations.csv file.")
+
+  # test error when customTranslationSource = "csv" but no file "translations.csv" in locale folder
+  localeDir <- system.file("tests", "testthat", "locale", package = "shi18ny")
+  opts <- list(
+    localeDir = localeDir,
+    availableLangs = c("en","es"),
+    customTranslationSource = "csv"
+  )
+  config <- i18nConfig(opts)
+  expect_error(i18nLoad(opts), "Need translations.csv file in locale folder.")
+
+  # test error when "translations.csv" has no id column
+  localeDir <- system.file("tests", "testthat", "locale_csv", package = "shi18ny")
+  opts <- list(
+    localeDir = localeDir,
+    availableLangs = c("en","es"),
+    customTranslationSource = "csv"
+  )
+  config <- i18nConfig(opts)
+  expect_error(i18nLoad(opts), "Need id column for translations.")
+
 
 
 })


### PR DESCRIPTION
Fixes #27 

Translations can now be done from a csv with an `id` column and one or multiple language columns (e.g. `en`, `es`, etc).

To use a csv translations, the csv file needs to be located in the locale directory (by default "locale") and needs to be called `translations.csv`. 

To use translations from csv, the `customTranslationSource` parameter needs to be passed to `i18nLoad` as follows (default for this parameter is `yaml`).
```
i18n <- list(
    defaultLang = "en",
    availableLangs = c("de","en","es"),
    customTranslationSource = "csv"
  )

lang <- callModule(langSelector,"lang", i18n = i18n, showSelector = TRUE)
```

Note that at the moment, for this to work, all translation functions in the app also need to be passed the `i18n` parameter: 
`i_("translation_id", lang = lang(), i18n = i18n)` 